### PR TITLE
Add class and toString() for dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,18 +62,26 @@ function parse_desc_stream(descstream, callback) {
     descstream.on('end', finisher);
 }
 
+function Dependency(package, version) {
+  this.package = package;
+  if(version)
+    this.version = version;
+}
+
+Dependency.prototype.toString = function() {
+  return this.package + (this.version ? " (" + this.version + ")" : "");
+}
+
 function parse_dep(str) {
   return str.split(/,[\s]*/s).filter(function(str){
     return str.trim(); //filter out empty strings
   }).map(function(str){
     return str.match(/\(.+\)/s) ?
-        {
-            package: normalize_ws(str.replace(/\(.+\)/s, '')),
-            version: normalize_ws(str.replace(/.*\((.+)\)/s, '$1'))
-        } : {
-            package: normalize_ws(str)
-        };
-    });
+      new Dependency(
+        normalize_ws(str.replace(/\(.+\)/s, '')),
+        normalize_ws(str.replace(/.*\((.+)\)/s, '$1'))
+      ) : new Dependency(normalize_ws(str));
+  });
 }
 
 function parse_remotes(str) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdesc-parser",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Parser for R package DESCRIPTION files.",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -3,6 +3,10 @@ var test = require('ava');
 var fs = require('fs');
 var desc = require('.');
 
+function jsondata(object) {
+    return JSON.parse(JSON.stringify(object));
+}
+
 test.cb('D1', function(t) {
     desc(fs.createReadStream('./test/D1', { 'encoding': 'utf8' }),
 	 function(err, d) {
@@ -21,11 +25,14 @@ test.cb('D2', function(t) {
 	     t.is(d.Package, 'roxygen2');
 	     t.is(d.Depends.length, 1);
          t.is(d.Imports.length, 8);
-	     t.deepEqual(d.Depends[0], {package: 'R', version: '>= 3.0.2'});
-         t.deepEqual(d.Imports[0], {package: 'stringr', version: '>= 0.5'});
-         t.deepEqual(d.Imports[1], {package: 'stringi'});
-         t.deepEqual(d.Imports[5], {package: 'Rcpp', version: '>= 0.11.0'});
-         t.deepEqual(d.Suggests[0], {package: 'testthat', version: '>= 0.8.0'});
+         t.deepEqual(jsondata(d.Depends[0]), {package: 'R', version: '>= 3.0.2'});
+         t.deepEqual(jsondata(d.Imports[0]), {package: 'stringr', version: '>= 0.5'});
+         t.deepEqual(jsondata(d.Imports[1]), {package: 'stringi'});
+         t.deepEqual(jsondata(d.Imports[5]), {package: 'Rcpp', version: '>= 0.11.0'});
+         t.deepEqual(jsondata(d.Suggests[0]), {package: 'testthat', version: '>= 0.8.0'});
+         t.is(d.Depends[0]+'', 'R (>= 3.0.2)');
+         t.is(d.Imports[0]+'', 'stringr (>= 0.5)');
+         t.is(d.Imports[1]+'', 'stringi');
          t.end();
 	 });
 });


### PR DESCRIPTION
This is a small change that gives dependency instances type `Dependency` such that we can add a `toString()` method to the prototype, which restores the original string.

This mostly restores backward compatibility with rdesc-parser 2.x :)