### PR TITLE
Fix memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,17 +117,15 @@ function parse_tar_stream(descstream, callback) {
     var done = false;
 
     extract.on('entry', function(header, tarstream, tarcb) {
+        tarstream.on('end', tarcb);
         if (!done && header.name.match(/^[^\/]+\/DESCRIPTION$/)) {
             done = true;
             parse_desc_stream(tarstream, function(err, d) {
-                extract.destroy();
                 callback(err, d);
             });
         } else {
-            tarcb()
+            tarstream.resume();
         }
-
-        tarstream.resume();
     });
 
     extract.on('finish', function() {
@@ -136,7 +134,6 @@ function parse_tar_stream(descstream, callback) {
 
     extract.on('error', function(err) {
         callback(err);
-        extract.destroy();
     })
 
     descstream

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "homepage": "https://github.com/r-hub/rdesc-parser#readme",
   "dependencies": {
     "byline": "^4.2.1",
-    "file-type": "^12.3.1",
-    "gunzip-maybe": "^1.4.1",
+    "file-type": "^16.5.4",
+    "gunzip-maybe": "^1.4.2",
     "r-constants": "^1.0.0",
-    "tar-stream": "^2.1.0",
-    "unzipper": "^0.10.5"
+    "tar-stream": "^3.1.7",
+    "unzipper": "^0.12.3"
   },
   "devDependencies": {
     "ava": "^2.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdesc-parser",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Parser for R package DESCRIPTION files.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update some dependencies and use the extract pattern from the [upstream readme](https://github.com/mafintosh/tar-stream?tab=readme-ov-file#extracting) which does not explicitly destroy the tar stream from the callbacks. This leads to memory leaks in my application, I think because the database stream is getting into a weird state when the pipe breaks.


Fixes #11.